### PR TITLE
스티커 기능 개발

### DIFF
--- a/blockboard/src/main/java/com/board/project/blockboard/controller/StickerController.java
+++ b/blockboard/src/main/java/com/board/project/blockboard/controller/StickerController.java
@@ -1,0 +1,35 @@
+package com.board.project.blockboard.controller;
+
+import com.board.project.blockboard.service.StickerService;
+import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.json.simple.JSONObject;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * @author Woohyeok Jun <woohyeok.jun@worksmobile.com>
+ * @file StickerController.java
+ */
+@Slf4j
+@RestController
+public class StickerController {
+
+  @Autowired
+  private StickerService stickerService;
+
+  @GetMapping("/sticker")
+  public JSONObject getStickers(HttpServletRequest request) {
+    return stickerService.getStickers(request);
+  }
+
+  @GetMapping(value = "/sticker/{directory}/{fileName}", produces = MediaType.IMAGE_PNG_VALUE)
+  public byte[] getSticker(@PathVariable("directory") String dirName,
+      @PathVariable("fileName") String fileName) throws IOException {
+    return stickerService.getSticker(dirName, fileName);
+  }
+}

--- a/blockboard/src/main/java/com/board/project/blockboard/service/StickerService.java
+++ b/blockboard/src/main/java/com/board/project/blockboard/service/StickerService.java
@@ -1,0 +1,115 @@
+package com.board.project.blockboard.service;
+
+import com.board.project.blockboard.common.util.JsonParse;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import javax.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.IOUtils;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.springframework.stereotype.Service;
+
+/**
+ * @author Woohyeok Jun <woohyeok.jun@worksmobile.com>
+ * @file StickerService.java
+ */
+
+@Slf4j
+@Service
+public class StickerService {
+
+  private final String STICKER_PATH = "/home1/irteam/storage/sticker";
+
+  private final Map<String, Object> cache_stickerList = new HashMap<>();
+
+  private final ArrayList<String> cache_groupNames = new ArrayList<>();
+
+  long start, end;
+
+  public JSONObject getStickers(HttpServletRequest request) {
+    start = System.nanoTime();
+    if (cache_stickerList.isEmpty() || this.isModify()) {
+      JSONArray stickers = new JSONArray();
+      JSONArray groups = new JSONArray();
+      ArrayList<String> groupNames = new ArrayList<>();
+      int count = -1;
+      // 하위 디렉토리
+      for (File info : Objects.requireNonNull(new File(STICKER_PATH).listFiles())) {
+        if (info.isDirectory()) {
+          String newPath = STICKER_PATH + "/" + info.getName();
+          JSONObject group = new JSONObject();
+          JSONObject position = new JSONObject();
+          position.put("x", (count--) * 21);
+          position.put("y", 0);
+          group.put("groupName", info.getName());
+          groupNames.add(info.getName());
+          group.put("position", position);
+          for (File sub_info : Objects.requireNonNull(new File(newPath).listFiles())) {
+            if (sub_info.isFile() && !sub_info.getName().startsWith("nav")) {
+              JSONObject sticker = new JSONObject();
+              sticker.put("groupName", info.getName());
+              sticker.put("id", sub_info.getName());
+              sticker.put("src",
+                  request.getContextPath() + "/sticker/" + info.getName() + "/" + sub_info
+                      .getName());
+              stickers.add(sticker);
+            } else if (sub_info.getName().startsWith("nav")) {
+              group.put("navsrc",
+                  request.getContextPath() + "/sticker/" + info.getName() + "/" + sub_info
+                      .getName());
+            }
+          }
+          groups.add(group);
+        }
+      }
+
+      JSONObject result = new JSONObject();
+      result.put("groups", groups);
+      result.put("items", stickers);
+      cache_stickerList.putAll(result);
+      cache_groupNames.addAll(groupNames);
+      end = System.nanoTime();
+      log.info("getStickers: " + (end - start) / 1000000.0);
+      return result;
+    }
+    end = System.nanoTime();
+    log.info("getStickers: " + (end - start) / 1000000.0);
+    return JsonParse.getJsonStringFromMap(cache_stickerList);
+  }
+
+  public byte[] getSticker(String dirName, String fileName) throws IOException {
+    start = System.nanoTime();
+    String requestPath = STICKER_PATH + "/" + dirName + "/" + fileName;
+    InputStream in = new FileInputStream(requestPath);
+    byte[] imageByteArray = IOUtils.toByteArray(in);
+    in.close();
+    end = System.nanoTime();
+    return imageByteArray;
+  }
+
+  public boolean isModify() {
+    int directoryCount = 0;
+
+    for (File info : Objects.requireNonNull(new File(STICKER_PATH).listFiles())) {
+      if(info.isDirectory()) {
+        directoryCount++;
+        if (!cache_groupNames.contains(info.getName())) {
+          cache_groupNames.clear();
+          cache_stickerList.clear();
+          return true;
+        }
+      }
+    }
+    if (directoryCount != cache_groupNames.size()) {
+      return true;
+    }
+    return false;
+  }
+}

--- a/blockboard/src/main/resources/static/ckeditor/config.js
+++ b/blockboard/src/main/resources/static/ckeditor/config.js
@@ -1,0 +1,83 @@
+/**
+ * @license Copyright (c) 2003-2019, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+CKEDITOR.editorConfig = function (config) {
+  // Define changes to default configuration here.
+  // For complete reference see:
+  // https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html
+
+  // The toolbar groups arrangement, optimized for a single toolbar row.
+  config.toolbarGroups = [
+    {name: 'document', groups: ['mode', 'document', 'doctools']},
+    {name: 'clipboard', groups: ['clipboard', 'undo']},
+    {name: 'editing', groups: ['find', 'selection', 'spellchecker']},
+    {name: 'forms'},
+    {name: 'basicstyles', groups: ['basicstyles', 'cleanup']},
+    {name: 'paragraph', groups: ['list', 'indent', 'blocks', 'align', 'bidi']},
+    {name: 'links'},
+    {name: 'insert'},
+    {name: 'styles'},
+    {name: 'colors'},
+    {name: 'tools'},
+    {name: 'others'},
+    {name: 'about'}
+  ];
+
+  // 에디터의 높이
+  config.height = 400;
+
+  // 에디터에서 ENTER 키 처리를 <br>로 하게 한다.
+  config.enterMode = CKEDITOR.ENTER_BR;
+
+  // 에디터에서 '파일찾기' 할 때의 경로
+  config.filebrowserImageUploadUrl = "/imageUpload";
+
+  // 에디터의 추가 플러그인 설정
+  config.extraPlugins = 'dialog, '
+      + 'filebrowser, '
+      + 'filetools, '
+      + 'popup, '
+      + 'widget, '
+      + 'widgetselection, '
+      + 'lineutils, '
+      + 'contextmenu, '
+      + 'menu, '
+      + 'floatpanel, '
+      + 'panel, '
+      + 'uploadimage, '
+      + 'uploadwidget,'
+      + 'notificationaggregator,'
+      + 'floatpanel,'
+      + 'panelbutton,'
+      + 'button,'
+      + 'xml,'
+      + 'ajax';
+
+  if ($('#functionAble4').attr("value") == "on") {
+    config.extraPlugins = "image2";
+  }
+
+  if ($('#functionAble6').attr("value") == "on") {
+    config.extraPlugins = "emoji";
+  }
+
+  // The default plugins included in the basic setup define some buttons that
+  // are not needed in a basic editor. They are removed here.
+	config.removeButtons = 'Strike,Subscript,Superscript';
+
+	CKEDITOR.on('dialogDefinition', function (evt) {
+		var dialog = evt.data;
+
+		if (dialog.name == 'sticker') {
+			// Get dialog definition.
+			var dialogDefinition = evt.data.definition;
+
+			console.log(dialogDefinition);
+			dialogDefinition.dialog.resize(300,200);
+		}
+	});
+  // Dialog windows are also simplified.
+  config.removeDialogTabs = 'link:advanced';
+};

--- a/blockboard/src/main/resources/static/ckeditor/plugins/emoji/plugin.js
+++ b/blockboard/src/main/resources/static/ckeditor/plugins/emoji/plugin.js
@@ -1,0 +1,354 @@
+/**
+ * @license Copyright (c) 2003-2020, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+(function () {
+  'use strict';
+  let groupList = [];
+  var stylesLoaded = false,
+      arrTools = CKEDITOR.tools.array,
+      htmlEncode = CKEDITOR.tools.htmlEncode,
+      EmojiDropdown = CKEDITOR.tools.createClass({
+        $: function (editor, plugin) {
+          var self = this,
+              ICON_SIZE = 28;
+
+          this.listeners = [];
+          this.plugin = plugin;
+          this.editor = editor;
+
+          // Keeps html elements references to not find them again.
+          this.elements = {};
+
+          // Name is responsible for icon name also.
+          editor.ui.add('EmojiPanel', CKEDITOR.UI_PANELBUTTON, {
+            label: '스티커',
+            title: '스티커',
+            modes: {wysiwyg: 1},
+            editorFocus: 0,
+            toolbar: 'insert',
+            panel: {
+              css: [
+                CKEDITOR.skin.getPath('editor'),
+                plugin.path + 'skins/default.css'
+              ],
+              attributes: {
+                role: 'listbox',
+                'aria-label': this.title
+              },
+              markFirst: false
+            },
+
+            onBlock: function (panel, block) {
+              var keys = block.keys;
+
+              keys[39] = 'next'; // ARROW-RIGHT
+              keys[40] = 'next'; // ARROW-DOWN
+              keys[9] = 'next'; // TAB
+              keys[37] = 'prev'; // ARROW-LEFT
+              keys[38] = 'prev'; // ARROW-UP
+              keys[CKEDITOR.SHIFT + 9] = 'prev'; // SHIFT + TAB
+              keys[32] = 'click'; // SPACE
+
+              self.blockElement = block.element;
+              self.emojiList = self.editor._.emoji.list;
+              self.addEmojiToGroups();
+
+              block.element.getAscendant('html').addClass('cke_emoji');
+              block.element.getDocument().appendStyleSheet(
+                  CKEDITOR.getUrl(CKEDITOR.basePath + 'contents.css'));
+              block.element.addClass('cke_emoji-panel_block');
+              block.element.setHtml(self.createEmojiBlock());
+              block.element.removeAttribute('title');
+              panel.element.addClass('cke_emoji-panel');
+              self.items = block._.getItems();
+              self.blockObject = block;
+              self.elements.emojiItems = block.element.find(
+                  '.cke_emoji-outer_emoji_block li > img');
+              self.elements.emojiBlock = block.element.findOne(
+                  '.cke_emoji-outer_emoji_block');
+              self.elements.navigationItems = block.element.find('nav li');
+              self.elements.sections = block.element.find('section');
+              self.registerListeners();
+
+            },
+
+            onOpen: self.openReset()
+          });
+        },
+        proto: {
+          registerListeners: function () {
+            arrTools.forEach(this.listeners, function (item) {
+              var root = this.blockElement,
+                  selector = item.selector,
+                  listener = item.listener,
+                  event = item.event,
+                  ctx = item.ctx || this;
+
+              arrTools.forEach(root.find(selector).toArray(), function (node) {
+                node.on(event, listener, ctx);
+              });
+            }, this);
+          },
+          createEmojiBlock: function () {
+            var output = [];
+            output.push(this.createGroupsNavigation());
+            output.push(this.createEmojiListBlock());
+
+            return '<div class="cke_emoji-inner_panel">' + output.join('')
+                + '</div>';
+          },
+          createGroupsNavigation: function () {
+            var itemTemplate,
+                items,
+                imgUrl;
+
+            imgUrl = "https://storep-phinf.pstatic.net/linesweet_01/original_m_tab_on.png?type=m48_37";
+            // 스티커 카테고리 추가 부분
+            itemTemplate = new CKEDITOR.template(
+                '<li class="cke_emoji-navigation_item" data-cke-emoji-group="{group}">' +
+                '<a draggable="false" title="{group}">' +
+                '<span style="background-image:url({navSRC});background-size: cover;' +
+                'background-repeat:no-repeat;"></span>' +
+                '</a></li>'
+            );
+
+            items = arrTools.reduce(groupList, function (acc, item) {
+              if (!item.items.length) {
+                return acc;
+              } else {
+                return acc + itemTemplate.output({
+                  group: htmlEncode(item.groupName),
+                  positionX: item.position.x,
+                  positionY: item.position.y,
+                  navSRC: item.navsrc
+                });
+              }
+            }, '');
+            this.listeners.push({
+              selector: 'nav',
+              event: 'click',
+              listener: function (event) {
+                var activeElement = event.data.getTarget().getAscendant('li',
+                    true);
+                var refreshItems;
+                if (!activeElement) {
+                  return;
+                }
+                arrTools.forEach(this.elements.navigationItems.toArray(),
+                    function (node, index) {
+                      if (node.equals(activeElement)) {
+                        refreshItems = groupList[index];
+                        node.addClass('active');
+                      } else {
+                        node.removeClass('active');
+                      }
+                    });
+                // 선택한 스티커 그룹으로 목록 갱신
+                var newHTML = this.getEmojiSection(refreshItems);
+                this.elements.emojiBlock.setHtml(newHTML);
+                this.elements.emojiBlock.$.scrollTop = 0;
+                this.registerListeners();
+              }
+            });
+
+            return '<nav><ul>' + items + '</ul></nav>';
+          },
+          createEmojiListBlock: function () {
+            var self = this;
+            this.listeners.push({
+              selector: '.cke_emoji-outer_emoji_block',
+              event: 'scroll',
+              listener: (function () {
+                var buffer = CKEDITOR.tools.throttle(150,
+                    self.refreshNavigationStatus, self);
+                return buffer.input;
+              })()
+            });
+
+            this.listeners.push({
+              selector: '.sticker',
+              event: 'click',
+              listener: function (event) {
+                this.editor.execCommand('insertSticker', {
+                  sticker: event.data.getTarget()
+                });
+              }
+            });
+            return '<div id="sticker_area" class="cke_emoji-outer_emoji_block">'
+                + this.getEmojiSection(groupList[0]) + '</div>';
+          },
+          getEmojiSection: function (item) {
+            var groupName = htmlEncode(item.groupName),
+                group = this.getEmojiListGroup(item.items);
+            return '<section data-cke-emoji-group="' + groupName + '" ><ul>'
+                + group + '</ul></section>';
+          },
+          getEmojiListGroup: function (items) {
+            var emojiTpl = new CKEDITOR.template('<li class="cke_emoji-item">' +
+                '<img class="sticker" width="120" height="auto" draggable="false" '
+                + 'data-cke-emoji-group="{groupName}" src="{src}"></li>');
+
+            return arrTools.reduce(
+                items,
+                function (acc, item) {
+                  addEncodedName(item);
+                  return acc + emojiTpl.output({
+                    src: htmlEncode(item.src),
+                    groupName: htmlEncode(item.groupName),
+                  });
+                },
+                '',
+                this
+            );
+          },
+          openReset: function () {
+            // Resets state of emoji dropdown.
+            // Clear filters, reset focus, etc.
+            var self = this,
+                firstCall;
+
+            return function () {
+              if (!firstCall) {
+                firstCall = true;
+              }
+              self.elements.emojiBlock.$.scrollTop = 0;
+              self.refreshNavigationStatus();
+            };
+          },
+          refreshNavigationStatus: function () {
+            var containerOffset = this.elements.emojiBlock.getClientRect().top,
+                section,
+                groupName;
+
+            section = arrTools.filter(this.elements.sections.toArray(),
+                function (element) {
+                  var rect = element.getClientRect();
+                  if (!rect.height) {
+                    return false;
+                  }
+                  return rect.height + rect.top > containerOffset;
+                });
+            groupName = section.length ? section[0].data('cke-emoji-group')
+                : false;
+
+            arrTools.forEach(this.elements.navigationItems.toArray(),
+                function (node) {
+                  if(!groupName) {
+                    return;
+                  }
+                  if (node.data('cke-emoji-group') === groupName) {
+                    node.addClass('active');
+                  } else {
+                    node.removeClass('active');
+                  }
+                });
+            this.moveFocus(groupName);
+          },
+          moveFocus: function( groupName ) {
+            var firstSectionItem = this.blockElement.findOne( 'a[data-cke-emoji-group="' + htmlEncode( groupName ) + '"]' ),
+                itemIndex;
+
+            if ( !firstSectionItem ) {
+              return;
+            }
+
+            itemIndex = this.getItemIndex( this.items, firstSectionItem );
+            //firstSectionItem.focus( true );
+            //firstSectionItem.getAscendant( 'section' ).getFirst().scrollIntoView( true );
+            this.blockObject._.markItem( itemIndex );
+          },
+          getItemIndex: function( nodeList, item ) {
+            return arrTools.indexOf( nodeList.toArray(), function( element ) {
+              return element.equals( item );
+            } );
+          },
+          addEmojiToGroups: function () {
+            var groupObj = {};
+            arrTools.forEach(groupList, function (group) {
+              groupObj[group.groupName] = group.items;
+            }, this);
+
+            arrTools.forEach(this.emojiList, function (emojiObj) {
+              groupObj[emojiObj.groupName].push(emojiObj);
+            }, this);
+          }
+        }
+      });
+
+  CKEDITOR.plugins.add('emoji', {
+    requires: 'ajax,panelbutton,floatpanel',
+    icons: 'emojipanel',
+    hidpi: true,
+
+    isSupportedEnvironment: function () {
+      return !CKEDITOR.env.ie || CKEDITOR.env.version >= 11;
+    },
+
+    beforeInit: function () {
+      if (!this.isSupportedEnvironment()) {
+        return;
+      }
+      if (!stylesLoaded) {
+        CKEDITOR.document.appendStyleSheet(this.path + 'skins/default.css');
+        stylesLoaded = true;
+      }
+    },
+
+    init: function (editor) {
+      if (!this.isSupportedEnvironment()) {
+        return;
+      }
+
+      var stickerListUrl = '/sticker';
+      var plugin = this;
+
+      CKEDITOR.ajax.load(CKEDITOR.getUrl(stickerListUrl), function (data) {
+        if (data === null) {
+          return;
+        }
+        if (editor._.emoji === undefined) {
+          editor._.emoji = {};
+        }
+
+        if (editor._.emoji.list === undefined) {
+          groupList = JSON.parse(data).groups;
+          $.each(groupList, function (index) {
+            groupList[index].items = [];
+          });
+          editor._.emoji.list = JSON.parse(data).items;
+        }
+
+        if (editor.plugins.toolbar) {
+          new EmojiDropdown(editor, plugin);
+        }
+      });
+
+      editor.addCommand('insertSticker', {
+        exec: function (editor, data) {
+          var cloneElement = data.sticker.clone();
+          cloneElement.setAttributes({
+            "class": "sticker",
+            "width": "auto",
+            "height": "auto"
+          });
+          editor.insertElement(cloneElement);
+        }
+      });
+
+      if (editor.plugins.toolbar) {
+        new EmojiDropdown(editor, this);
+      }
+
+    }
+  });
+
+  function addEncodedName(item) {
+    if (!item.name) {
+      item.name = htmlEncode(
+          item.id.replace(/::.*$/, ':').replace(/^:|:$/g, ''));
+    }
+    return item;
+  }
+})();


### PR DESCRIPTION
closed #16 
# 기능 상세

**1. 일정상 클라우드를 적용하지 않고 스티커 데이터는 로컬에 저장하였습니다.**

**2. CKEditor의 'emoji' Plugin을 대폭 수정하여 최대한 웍스와 비슷하게 만들었습니다.**

**3. '글쓰기' 버튼을 누를 때 스티커 데이터를 받아오는 요청을 보냅니다.**

>    * 이 과정에서 서버에 계속 요청이 가면 부담이 올 것 같아 싱글톤패턴을 적용하였습니다.
>    * final 변수에 스티커 데이터, 스티커 폴더명들을 요청이 올 때 최초로 저장합니다.
---

>    * 위 사항들을 수정하여 AWS S3로 변경할 예정입니다.
   * 요청이 오면 스티커를 최초로 불러올 때나 로컬에서 스티커가 추가되거나 삭제되었을 시에만 새로 데이터를 갱신하도록 하였습니다.
   * 서버에서 GET 요청에 대한 시간을 측정해보니 두번째 요청부터는 처리시간이 대폭 감소한 것을 확인할 수 있었습니다.

